### PR TITLE
eAPI v1.7 - add merchantData, button

### DIFF
--- a/pycsob/__init__.py
+++ b/pycsob/__init__.py
@@ -1,2 +1,2 @@
-__version__ = (0, 3, 1)
+__version__ = (0, 4, 0)
 __versionstr__ = '.'.join(map(str, __version__))

--- a/pycsob/client.py
+++ b/pycsob/client.py
@@ -103,6 +103,10 @@ class CsobClient(object):
                 ])
             ]
 
+        # Fix invalid language code type (country code).
+        lang_code = language.upper()[:2]
+        language = {'CS': 'CZ'}.get(lang_code, lang_code)
+
         payload = utils.mk_payload(self.f_key, pairs=(
             ('merchantId', self.merchant_id),
             ('orderNo', str(order_no)),

--- a/pycsob/client.py
+++ b/pycsob/client.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-from base64 import b64encode
+from base64 import b64encode, b64decode
 import json
 import logging
 import requests
@@ -89,7 +89,7 @@ class CsobClient(object):
             raise ValueError('Description length is over 255 chars')
 
         if merchant_data:
-            merchant_data = b64encode(merchant_data)
+            merchant_data = b64encode(merchant_data).decode("UTF-8")
             if len(merchant_data) > 255:
                 raise ValueError('Merchant data length encoded to BASE64 is over 255 chars')
 
@@ -151,6 +151,8 @@ class CsobClient(object):
                 o[k] = int(datadict[k]) if k in ('resultCode', 'paymentStatus') else datadict[k]
         if not utils.verify(o, datadict['signature'], self.f_pubkey):
             raise utils.CsobVerifyError('Unverified gateway return data')
+        if 'merchantData' in o:
+            o['merchantData'] = b64decode(o['merchantData'])
         return o
 
     def payment_status(self, pay_id):

--- a/pycsob/client.py
+++ b/pycsob/client.py
@@ -21,6 +21,7 @@ class HTTPAdapter(requests.adapters.HTTPAdapter):
 
 
 class CsobClient(object):
+
     def __init__(self, merchant_id, base_url, private_key_file, csob_pub_key_file):
         """
         Initialize Client
@@ -267,3 +268,15 @@ class CsobClient(object):
             if v not in conf.EMPTY_VALUES:
                 pairs += ((k, v),)
         return utils.mk_payload(keyfile=self.f_key, pairs=pairs)
+
+    def button(self, pay_id, brand):
+        "Get url to the button."
+        payload = utils.mk_payload(self.f_key, pairs=(
+            ('merchantId', self.merchant_id),
+            ('payId', pay_id),
+            ('brand', brand),
+            ('dttm', utils.dttm()),
+        ))
+        url = utils.mk_url(base_url=self.base_url, endpoint_url='payment/button/')
+        r = self._client.post(url, data=json.dumps(payload))
+        return utils.validate_response(r, self.f_pubkey)

--- a/pycsob/client.py
+++ b/pycsob/client.py
@@ -1,4 +1,5 @@
 # coding: utf-8
+from base64 import b64encode
 import json
 import logging
 import requests
@@ -46,7 +47,7 @@ class CsobClient(object):
     def payment_init(self, order_no, total_amount, return_url, description, cart=None,
                      customer_id=None, currency='CZK', language='CZ', close_payment=True,
                      return_method='POST', pay_operation='payment', ttl_sec=600,
-                     logo_version=None, color_scheme_version=None):
+                     logo_version=None, color_scheme_version=None, merchant_data=None):
         """
         Initialize transaction, sum of cart items must be equal to total amount
         If cart is None, we create it for you from total_amount and description values.
@@ -77,11 +78,20 @@ class CsobClient(object):
         :param close_payment:
         :param return_method: method which be used for return to shop from gateway POST (default) or GET
         :param pay_operation: `payment` or `oneclickPayment`
+        :param ttl_sec: number of seconds to the timeout
+        :param logo_version: Logo version number
+        :param color_scheme_version: Color scheme version number
+        :param merchant_data: bytearray of merchant data
         :return: response from gateway as OrderedDict
         """
 
         if len(description) > 255:
             raise ValueError('Description length is over 255 chars')
+
+        if merchant_data:
+            merchant_data = b64encode(merchant_data)
+            if len(merchant_data) > 255:
+                raise ValueError('Merchant data length encoded to BASE64 is over 255 chars')
 
         # fill cart if not set
         if not cart:
@@ -106,6 +116,7 @@ class CsobClient(object):
             ('returnMethod', return_method),
             ('cart', cart),
             ('description', description),
+            ('merchantData', merchant_data),
             ('customerId', customer_id),
             ('language', language),
             ('ttlSec', ttl_sec),

--- a/pycsob/conf.py
+++ b/pycsob/conf.py
@@ -6,7 +6,8 @@ HEADERS = {
     'user-agent': 'py-csob/%s' % __versionstr__,
 }
 EMPTY_VALUES = ('', None, [], (), {})
-RESPONSE_KEYS = 'payId', 'customerId', 'dttm', 'resultCode', 'resultMessage', 'paymentStatus', 'authCode'
+RESPONSE_KEYS = ('payId', 'customerId', 'dttm', 'resultCode', 'resultMessage', 'paymentStatus', 'authCode',
+                 'merchantData')
 
 # available languages and currencies
 LANGUAGES = 'CZ', 'EN', 'DE', 'SK', 'HU', 'IT', 'JP', 'PL', 'PT', 'RO', 'RU', 'SK', 'ES', 'TR', 'VN'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [wheel]
 universal = 1
 
-[pytest]
+[tool:pytest]
 norecursedirs=.hg .idea .ropeproject tmp settings site_media static .env .git .tox build dist fixtures
 addopts = tests_pycsob -vv --cov=pycsob --cov-report term-missing


### PR DESCRIPTION
Update for eAPI v1.7:
 *  Add command `button`
 *  Add parameter `merchant_data` into command `init`.
 *  Support of recognition of posix locale `cs_CZ.utf8`.
