### PR TITLE
Dttm to dttime

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,8 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/python:3.6
+    steps:
+      - checkout
+      - run: python setup.py test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.6] - 2019-10-18
+
+### Added
+- Add CHANGELOG.md.
+
+### Changed
+- Fix begins/ends whitespaces on cart name.
+
+## [0.5] - 2019-05-15
+
+### Changed
+- Support of API v1.7 - Merchant data.
+- Add dttm_decode.
+- Fix invalid language code type (country code).
+- Add circleci config.
+
+## [0.4]
+
+### Added
+- Add function button into CsobClient.

--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,8 @@
 pycsob
 ======
 
-.. image:: https://circleci.com/gh/TwistoPayments/pycsob.svg?style=svg
-   :target: https://circleci.com/gh/TwistoPayments/pycsob
+.. image:: https://circleci.com/gh/zbohm/pycsob/tree/dttm.svg?style=svg
+   :target: https://circleci.com/gh/zbohm/pycsob/tree/dttm
 
 .. image:: https://badge.fury.io/py/pycsob.svg
     :target: https://badge.fury.io/py/pycsob

--- a/README.rst
+++ b/README.rst
@@ -7,6 +7,18 @@ pycsob
 .. image:: https://badge.fury.io/py/pycsob.svg
     :target: https://badge.fury.io/py/pycsob
 
+.. image:: https://img.shields.io/pypi/dm/pycsob.svg
+	   :target: https://pypi.python.org/pypi/pycsob
+
+.. image:: https://img.shields.io/pypi/status/pycsob.svg
+	   :target: https://pypi.python.org/pypi/pycsob
+
+.. image:: https://img.shields.io/pypi/pyversions/pycsob.svg
+	   :target: https://pypi.python.org/pypi/pycsob
+
+.. image:: https://img.shields.io/pypi/l/pycsob.svg
+	   :target: https://raw.githubusercontent.com/zbohm/pycsob/master/LICENSE
+
 Install:
 --------
 

--- a/README.rst
+++ b/README.rst
@@ -21,13 +21,20 @@ Run tests:
 
     python setup.py test
 
+
+eAPI-v1.7 Wiki
+--------------
+
+https://github.com/csob/paymentgateway/wiki/eAPI-v1.7
+
+
 Basic usage:
 ------------
 
 .. code-block:: python
 
     from pycsob.client import CsobClient
-    c = CsobClient('MERCHANT_ID', 'https://iapi.iplatebnibrana.csob.cz/api/v1.6/',
+    c = CsobClient('MERCHANT_ID', 'https://iapi.iplatebnibrana.csob.cz/api/v1.7/',
                    '/path/to/your/private.key',
                    '/path/to/mips_iplatebnibrana.csob.cz.pub')
 
@@ -37,20 +44,22 @@ like ``payload`` or ``extensions``.
 .. code-block:: python
 
     r = c.payment_init(14, 1000000, 'http://twisto.dev/', 'Tesovaci nakup', customer_id='a@a.aa',
-                       return_method='GET', pay_operation='payment')
+                       return_method='GET', pay_operation='payment', merchant_data=[1, 2, 3])
     r.payload
     #[Out]# OrderedDict([('payId', 'b627c1e4e60fcBF'),
     #[Out]#              ('dttm', '20160615104254'),
     #[Out]#              ('resultCode', 0),
     #[Out]#              ('resultMessage', 'OK'),
-    #[Out]#              ('paymentStatus', 1)])
+    #[Out]#              ('paymentStatus', 1)]),
+    #[Out]#              ('merchantData', [1, 2, 3])]),
+    #[Out]#              ('dttime', datetime.datetime(2016, 6, 15, 10, 42, 54)),
 
 After payment init get URL to redirect to for payId obtained from previous step.
 
 .. code-block:: python
 
     c.get_payment_process_url('b627c1e4e60fcBF')
-    #[Out]# 'https://iapi.iplatebnibrana.csob.cz/api/v1.6/payment/process/MERCHANT_ID/b627c1e4e60fcBF/20160615104318/bla-bla-bla'
+    #[Out]# 'https://iapi.iplatebnibrana.csob.cz/api/v1.7/payment/process/MERCHANT_ID/b627c1e4e60fcBF/20160615104318/bla-bla-bla'
 
 After user have payment processed, browser redirects him to URL provided in ``payment_init()``.
 You can check payment status.
@@ -63,7 +72,8 @@ You can check payment status.
     #[Out]#              ('resultCode', 0),
     #[Out]#              ('resultMessage', 'OK'),
     #[Out]#              ('paymentStatus', 7),
-    #[Out]#              ('authCode', '042760')])
+    #[Out]#              ('authCode', '042760')]),
+    #[Out]#              ('dttime', datetime.datetime(2016, 6, 15, 10, 45, 1)),
 
 You can also use one-click payment methods. For this you need
 to call ``c.payment_init(pay_operation='oneclickPayment')``. After this transaction confirmed
@@ -77,7 +87,8 @@ you can use obtained ``payId`` as template for one-click payment.
     #[Out]#              ('dttm', '20160615104532'),
     #[Out]#              ('resultCode', 0),
     #[Out]#              ('resultMessage', 'OK'),
-    #[Out]#              ('paymentStatus', 1)])
+    #[Out]#              ('paymentStatus', 1)]),
+    #[Out]#              ('dttime', datetime.datetime(2016, 6, 15, 10, 45, 32)),
 
     r = c.oneclick_start('ff7d3e7c6c4fdBF')
     r.payload
@@ -85,7 +96,8 @@ you can use obtained ``payId`` as template for one-click payment.
     #[Out]#              ('dttm', '20160615104619'),
     #[Out]#              ('resultCode', 0),
     #[Out]#              ('resultMessage', 'OK'),
-    #[Out]#              ('paymentStatus', 2)])
+    #[Out]#              ('paymentStatus', 2)]),
+    #[Out]#              ('dttime', datetime.datetime(2016, 6, 15, 10, 46, 19)),
 
     r = c.payment_status('ff7d3e7c6c4fdBF')
     r.payload
@@ -94,7 +106,8 @@ you can use obtained ``payId`` as template for one-click payment.
     #[Out]#              ('resultCode', 0),
     #[Out]#              ('resultMessage', 'OK'),
     #[Out]#              ('paymentStatus', 7),
-    #[Out]#              ('authCode', '168164')])
+    #[Out]#              ('authCode', '168164')]),
+    #[Out]#              ('dttime', datetime.datetime(2016, 6, 15, 10, 46, 43)),
 
 Of course you can use standard requests's methods on ``response`` object.
 
@@ -112,7 +125,7 @@ Of course you can use standard requests's methods on ``response`` object.
     r = c.payment_status('1e058ff1d0d5aBF')
 
     r.request.url
-    #[Out]#  'https://iapi.iplatebnibrana.csob.cz/api/v1.6/payment/status/M1E3CB2577/1e058ff1d0d5aBF/20160615111034/HQKDHz7DTHL0lCn6OrAv%2BKQjGEr8KtdF42czAGCngCG0gWbuYTfJfO%2B5rHwAEWCl1XKiClYngLBI7Lu2mCJG8AP2Od7%2BAa5VXWcIjs0mSAsP60irR7M4Xl1NsXPe4bEhXAvAJU4yz3oV2vZ68QRB9vE7mk6OaLQade48yEFmX83FJPDQ4RSBOUqD3JPrKMMZ%2BkNEz0%2FMh94X7Zx3DrtwUVdKEyuX8Zf2MYwqzQh7mNBW6EZKxt7yKwS%2B0108GalXoD1n7ctjbtcyrbFAFKKLDgPNf%2BMlLBt8cwSSQ6J2xigI3P9T32L5YUg25kKr%2B4Dy%2FnwOKDntDszbGXQZdIBnTQ%3D%3D'
+    #[Out]#  'https://iapi.iplatebnibrana.csob.cz/api/v1.7/payment/status/M1E3CB2577/1e058ff1d0d5aBF/20160615111034/HQKDHz7DTHL0lCn6OrAv%2BKQjGEr8KtdF42czAGCngCG0gWbuYTfJfO%2B5rHwAEWCl1XKiClYngLBI7Lu2mCJG8AP2Od7%2BAa5VXWcIjs0mSAsP60irR7M4Xl1NsXPe4bEhXAvAJU4yz3oV2vZ68QRB9vE7mk6OaLQade48yEFmX83FJPDQ4RSBOUqD3JPrKMMZ%2BkNEz0%2FMh94X7Zx3DrtwUVdKEyuX8Zf2MYwqzQh7mNBW6EZKxt7yKwS%2B0108GalXoD1n7ctjbtcyrbFAFKKLDgPNf%2BMlLBt8cwSSQ6J2xigI3P9T32L5YUg25kKr%2B4Dy%2FnwOKDntDszbGXQZdIBnTQ%3D%3D'
 
     r.status_code
     #[Out]# 200

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,0 @@
-machine:
-  post:
-    - pyenv global 2.7.12 3.6.2

--- a/pycsob/__init__.py
+++ b/pycsob/__init__.py
@@ -1,2 +1,2 @@
-__version__ = (0, 5, 0)
+__version__ = (0, 6, 0)
 __versionstr__ = '.'.join(map(str, __version__))

--- a/pycsob/__init__.py
+++ b/pycsob/__init__.py
@@ -1,2 +1,2 @@
-__version__ = (0, 4, 0)
+__version__ = (0, 5, 0)
 __versionstr__ = '.'.join(map(str, __version__))

--- a/pycsob/__init__.py
+++ b/pycsob/__init__.py
@@ -1,2 +1,2 @@
-__version__ = (0, 3, 1)
+__version__ = (0, 4, 0)
 __versionstr__ = '.'.join(map(str, __version__))

--- a/pycsob/client.py
+++ b/pycsob/client.py
@@ -103,6 +103,10 @@ class CsobClient(object):
                 ])
             ]
 
+        # Fix invalid language code type (country code).
+        lang_code = language.upper()[:2]
+        language = {'CS': 'CZ'}.get(lang_code, lang_code)
+
         payload = utils.mk_payload(self.f_key, pairs=(
             ('merchantId', self.merchant_id),
             ('orderNo', str(order_no)),

--- a/pycsob/client.py
+++ b/pycsob/client.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-from base64 import b64encode
+from base64 import b64encode, b64decode
 import json
 import logging
 import requests
@@ -89,7 +89,7 @@ class CsobClient(object):
             raise ValueError('Description length is over 255 chars')
 
         if merchant_data:
-            merchant_data = b64encode(merchant_data)
+            merchant_data = b64encode(merchant_data).decode("UTF-8")
             if len(merchant_data) > 255:
                 raise ValueError('Merchant data length encoded to BASE64 is over 255 chars')
 
@@ -151,6 +151,8 @@ class CsobClient(object):
                 o[k] = int(datadict[k]) if k in ('resultCode', 'paymentStatus') else datadict[k]
         if not utils.verify(o, datadict['signature'], self.f_pubkey):
             raise utils.CsobVerifyError('Unverified gateway return data')
+        if 'merchantData' in o:
+            o['merchantData'] = b64decode(o['merchantData'])
         return o
 
     def payment_status(self, pay_id):

--- a/pycsob/client.py
+++ b/pycsob/client.py
@@ -21,6 +21,7 @@ class HTTPAdapter(requests.adapters.HTTPAdapter):
 
 
 class CsobClient(object):
+
     def __init__(self, merchant_id, base_url, private_key_file, csob_pub_key_file):
         """
         Initialize Client
@@ -267,3 +268,15 @@ class CsobClient(object):
             if v not in conf.EMPTY_VALUES:
                 pairs += ((k, v),)
         return utils.mk_payload(keyfile=self.f_key, pairs=pairs)
+
+    def button(self, pay_id, brand):
+        "Get url to the button."
+        payload = utils.mk_payload(self.f_key, pairs=(
+            ('merchantId', self.merchant_id),
+            ('payId', pay_id),
+            ('brand', brand),
+            ('dttm', utils.dttm()),
+        ))
+        url = utils.mk_url(base_url=self.base_url, endpoint_url='payment/button/')
+        r = self._client.post(url, data=json.dumps(payload))
+        return utils.validate_response(r, self.f_pubkey)

--- a/pycsob/client.py
+++ b/pycsob/client.py
@@ -1,4 +1,5 @@
 # coding: utf-8
+from base64 import b64encode
 import json
 import logging
 import requests
@@ -46,7 +47,7 @@ class CsobClient(object):
     def payment_init(self, order_no, total_amount, return_url, description, cart=None,
                      customer_id=None, currency='CZK', language='CZ', close_payment=True,
                      return_method='POST', pay_operation='payment', ttl_sec=600,
-                     logo_version=None, color_scheme_version=None):
+                     logo_version=None, color_scheme_version=None, merchant_data=None):
         """
         Initialize transaction, sum of cart items must be equal to total amount
         If cart is None, we create it for you from total_amount and description values.
@@ -77,11 +78,20 @@ class CsobClient(object):
         :param close_payment:
         :param return_method: method which be used for return to shop from gateway POST (default) or GET
         :param pay_operation: `payment` or `oneclickPayment`
+        :param ttl_sec: number of seconds to the timeout
+        :param logo_version: Logo version number
+        :param color_scheme_version: Color scheme version number
+        :param merchant_data: bytearray of merchant data
         :return: response from gateway as OrderedDict
         """
 
         if len(description) > 255:
             raise ValueError('Description length is over 255 chars')
+
+        if merchant_data:
+            merchant_data = b64encode(merchant_data)
+            if len(merchant_data) > 255:
+                raise ValueError('Merchant data length encoded to BASE64 is over 255 chars')
 
         # fill cart if not set
         if not cart:
@@ -106,6 +116,7 @@ class CsobClient(object):
             ('returnMethod', return_method),
             ('cart', cart),
             ('description', description),
+            ('merchantData', merchant_data),
             ('customerId', customer_id),
             ('language', language),
             ('ttlSec', ttl_sec),

--- a/pycsob/client.py
+++ b/pycsob/client.py
@@ -155,6 +155,8 @@ class CsobClient(object):
                 o[k] = int(datadict[k]) if k in ('resultCode', 'paymentStatus') else datadict[k]
         if not utils.verify(o, datadict['signature'], self.f_pubkey):
             raise utils.CsobVerifyError('Unverified gateway return data')
+        if "dttm" in o:
+            o["dttime"] = utils.dttm_decode(o["dttm"])
         if 'merchantData' in o:
             o['merchantData'] = b64decode(o['merchantData'])
         return o

--- a/pycsob/client.py
+++ b/pycsob/client.py
@@ -97,7 +97,7 @@ class CsobClient(object):
         if not cart:
             cart = [
                 OrderedDict([
-                    ('name', description[:20]),
+                    ('name', description[:20].strip()),
                     ('quantity', 1),
                     ('amount', total_amount)
                 ])

--- a/pycsob/conf.py
+++ b/pycsob/conf.py
@@ -6,7 +6,8 @@ HEADERS = {
     'user-agent': 'py-csob/%s' % __versionstr__,
 }
 EMPTY_VALUES = ('', None, [], (), {})
-RESPONSE_KEYS = 'payId', 'customerId', 'dttm', 'resultCode', 'resultMessage', 'paymentStatus', 'authCode'
+RESPONSE_KEYS = ('payId', 'customerId', 'dttm', 'resultCode', 'resultMessage', 'paymentStatus', 'authCode',
+                 'merchantData')
 
 # available languages and currencies
 LANGUAGES = 'CZ', 'EN', 'DE', 'SK', 'HU', 'IT', 'JP', 'PL', 'PT', 'RO', 'RU', 'SK', 'ES', 'TR', 'VN'

--- a/pycsob/utils.py
+++ b/pycsob/utils.py
@@ -74,6 +74,11 @@ def dttm(format_='%Y%m%d%H%M%S'):
     return datetime.datetime.now().strftime(format_)
 
 
+def dttm_decode(value):
+    """Decode dttm value '20190404091926' to the datetime object."""
+    return datetime.datetime.strptime(value, "%Y%m%d%H%M%S")
+
+
 def validate_response(response, key):
     response.raise_for_status()
 
@@ -87,6 +92,9 @@ def validate_response(response, key):
 
     if not verify(payload, signature, key):
         raise CsobVerifyError('Cannot verify response')
+
+    if "dttm" in payload:
+        payload["dttime"] = dttm_decode(payload["dttm"])
 
     response.extensions = []
     response.payload = payload

--- a/requirements-test.pip
+++ b/requirements-test.pip
@@ -1,3 +1,4 @@
 pytest>=2.9.0
 pytest-cov~=2.2.0
 urllib3-mock~=0.3.0
+freezegun

--- a/requirements-test.pip
+++ b/requirements-test.pip
@@ -1,4 +1,4 @@
-pytest>=2.9.0
-pytest-cov~=2.2.0
-urllib3-mock~=0.3.0
+pytest>=3.7.1
+pytest-cov~=2.7.1
+urllib3-mock~=0.3.3
 freezegun

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [wheel]
 universal = 1
 
-[pytest]
+[tool:pytest]
 norecursedirs=.hg .idea .ropeproject tmp settings site_media static .env .git .tox build dist fixtures
 addopts = tests_pycsob -vv --cov=pycsob --cov-report term-missing


### PR DESCRIPTION
In the gate response convert `dttm` with `string` to the new key `dttime` with instance of `datetime`. It is more "pythonic" and same process like convertion of `merchantData`. 

Update README for eAPI-v1.7.